### PR TITLE
Separate learning room into its own page with chat drawer

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -10,10 +10,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const textarea = document.getElementById('question');
   const historyContainer = document.getElementById('chat-history');
   const submitButton = form ? form.querySelector('button[type="submit"]') : null;
-  const openButton = document.getElementById('chat-open-button');
+  const toggleButton = document.getElementById('chat-toggle-button');
   const closeButton = document.getElementById('chat-close-button');
   const overlay = document.getElementById('chat-overlay');
-  const chatMediaQuery = typeof window.matchMedia === 'function' ? window.matchMedia('(max-width: 768px)') : null;
 
   if (!subjectId || !unitId || !form || !textarea || !historyContainer || !submitButton) {
     return;
@@ -21,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const conversation = [];
 
-  setupMobileSidebar();
+  setupSidebarToggle();
 
   appendBubble('system', '学習中の内容に関して聞きたいことがあれば、メッセージを送ってください。');
 
@@ -91,48 +90,46 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  function setupMobileSidebar() {
-    if (!openButton || !closeButton || !overlay || !chatMediaQuery) {
+  function setupSidebarToggle() {
+    if (!toggleButton || !closeButton || !overlay) {
       return;
     }
 
-    const closeSidebar = (returnFocus = true, isMobileView = chatMediaQuery.matches) => {
+    const closeSidebar = (returnFocus = true) => {
       chatSection.classList.remove('is-open');
       overlay.classList.remove('is-active');
       overlay.setAttribute('hidden', 'true');
       document.body.classList.remove('chat-sidebar-open');
-      openButton.setAttribute('aria-expanded', 'false');
+      chatSection.setAttribute('aria-hidden', 'true');
+      chatSection.setAttribute('inert', '');
+      toggleButton.setAttribute('aria-expanded', 'false');
 
-      if (isMobileView) {
-        chatSection.setAttribute('inert', '');
-        if (returnFocus) {
-          openButton.focus();
-        }
-      } else {
-        chatSection.removeAttribute('inert');
+      if (returnFocus) {
+        toggleButton.focus();
       }
     };
 
     const openSidebar = () => {
-      if (!chatMediaQuery.matches) {
-        return;
-      }
-
-      chatSection.removeAttribute('inert');
       chatSection.classList.add('is-open');
-      overlay.removeAttribute('hidden');
       overlay.classList.add('is-active');
+      overlay.removeAttribute('hidden');
       document.body.classList.add('chat-sidebar-open');
-      openButton.setAttribute('aria-expanded', 'true');
+      chatSection.removeAttribute('aria-hidden');
+      chatSection.removeAttribute('inert');
+      toggleButton.setAttribute('aria-expanded', 'true');
       closeButton.focus();
       scrollToBottom(historyContainer);
     };
 
-    const handleMediaChange = (event) => {
-      closeSidebar(false, event.matches);
+    const toggleSidebar = () => {
+      if (chatSection.classList.contains('is-open')) {
+        closeSidebar(true);
+      } else {
+        openSidebar();
+      }
     };
 
-    openButton.addEventListener('click', openSidebar);
+    toggleButton.addEventListener('click', toggleSidebar);
     closeButton.addEventListener('click', () => closeSidebar(true));
     overlay.addEventListener('click', () => closeSidebar(true));
 
@@ -143,13 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
 
-    handleMediaChange(chatMediaQuery);
-
-    if (typeof chatMediaQuery.addEventListener === 'function') {
-      chatMediaQuery.addEventListener('change', handleMediaChange);
-    } else if (typeof chatMediaQuery.addListener === 'function') {
-      chatMediaQuery.addListener(handleMediaChange);
-    }
+    closeSidebar(false);
   }
 
   function appendBubble(role, text) {

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -67,6 +67,10 @@ a {
     gap: 24px;
 }
 
+.app-main--learning {
+    gap: 32px;
+}
+
 .panel {
     background: var(--panel-background);
     border-radius: 16px;
@@ -130,10 +134,156 @@ a {
     background: #ffffff;
 }
 
+.start-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.start-panel__summary,
+.start-panel__meta,
+.start-panel__overview {
+    margin: 0;
+    color: var(--muted-text);
+}
+
+.start-panel__summary strong {
+    color: #1f3561;
+}
+
+.primary-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    padding: 12px 24px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 12px 30px rgba(63, 106, 216, 0.25);
+    transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button:hover {
+    background: #2e55c7;
+    transform: translateY(-1px);
+    box-shadow: 0 16px 36px rgba(63, 106, 216, 0.35);
+}
+
+.primary-button:focus-visible {
+    outline: 3px solid rgba(63, 106, 216, 0.4);
+    outline-offset: 4px;
+}
+
+.info-panel p {
+    margin: 0;
+    color: var(--muted-text);
+}
+
+.link-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.link-button::before {
+    content: '\2190';
+    font-size: 0.95rem;
+}
+
+.link-button:hover {
+    text-decoration: underline;
+}
+
 .learning-panel {
-    display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+    padding: 24px;
+}
+
+.learning-content {
+    display: flex;
+    flex-direction: column;
     gap: 24px;
+}
+
+.learning-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.learning-heading {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.learning-heading h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    color: #2d4a87;
+}
+
+.learning-return {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--muted-text);
+}
+
+.learning-meta {
+    margin: 0;
+    font-size: 0.95rem;
+    color: var(--muted-text);
+}
+
+.chat-toggle-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+    border: 1px solid var(--border-color);
+    background: #ffffff;
+    color: #243b6b;
+    border-radius: 999px;
+    padding: 10px 18px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 10px 24px rgba(63, 106, 216, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.chat-toggle-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 32px rgba(63, 106, 216, 0.3);
+    background: #f0f4ff;
+}
+
+.chat-toggle-button:focus-visible {
+    outline: 3px solid rgba(63, 106, 216, 0.35);
+    outline-offset: 3px;
+}
+
+.chat-toggle-button[aria-expanded="true"] {
+    background: var(--accent);
+    color: #fff;
+    border-color: transparent;
+    box-shadow: 0 12px 30px rgba(63, 106, 216, 0.35);
+}
+
+.chat-toggle-icon {
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.chat-toggle-button[aria-expanded="true"] .chat-toggle-icon {
+    color: inherit;
 }
 
 .learning-content h3 {
@@ -191,12 +341,55 @@ a {
 
 .tutor-chat {
     background: #fffaf0;
-    border-radius: 16px;
-    padding: 20px;
     border: 1px solid #fcd9a3;
     display: flex;
     flex-direction: column;
     gap: 12px;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(92vw, 360px);
+    max-width: 100%;
+    height: 100dvh;
+    padding: calc(24px + env(safe-area-inset-top)) 24px calc(32px + env(safe-area-inset-bottom));
+    border-radius: 0;
+    border-left: 1px solid #fcd9a3;
+    border-right: none;
+    border-top: none;
+    border-bottom: none;
+    box-shadow: -18px 0 36px rgba(15, 23, 42, 0.25);
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    z-index: 1100;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.tutor-chat.is-open {
+    transform: translateX(0);
+}
+
+@media (min-width: 1200px) {
+    .tutor-chat {
+        width: 400px;
+    }
+}
+
+.chat-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    z-index: 1090;
+}
+
+.chat-overlay.is-active {
+    display: block;
+}
+
+body.chat-sidebar-open {
+    overflow: hidden;
 }
 
 .chat-header {
@@ -210,38 +403,10 @@ a {
     margin: 0;
 }
 
-.chat-open-button {
-    display: none;
-    margin: 12px 0 0;
-    padding: 10px 18px;
-    background: var(--accent);
-    color: #fff;
-    border: none;
-    border-radius: 999px;
-    font-size: 0.95rem;
-    font-weight: 600;
-    cursor: pointer;
-    box-shadow: 0 10px 26px rgba(63, 106, 216, 0.35);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.chat-open-button:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 14px 32px rgba(63, 106, 216, 0.4);
-}
-
-.chat-open-button:active {
-    transform: translateY(0);
-    box-shadow: 0 8px 22px rgba(63, 106, 216, 0.35);
-}
-
-.chat-open-button:focus-visible {
-    outline: 3px solid rgba(63, 106, 216, 0.45);
-    outline-offset: 2px;
-}
-
 .chat-close-button {
-    display: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     background: none;
     border: none;
     color: #8b5c11;
@@ -249,6 +414,11 @@ a {
     cursor: pointer;
     padding: 4px 10px;
     border-radius: 999px;
+    font-size: 0.9rem;
+}
+
+.chat-close-button::before {
+    content: '\2715';
     font-size: 0.85rem;
 }
 
@@ -259,10 +429,6 @@ a {
 .chat-close-button:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
-}
-
-.chat-overlay {
-    display: none;
 }
 
 .chat-description,
@@ -331,7 +497,7 @@ a {
 }
 
 .chat-form button {
-    align-self: flex-end;
+    align-self: stretch;
     background: var(--accent);
     color: #fff;
     border: none;
@@ -355,99 +521,6 @@ a {
     padding: 24px 0 32px;
 }
 
-@media (max-width: 900px) {
-    .learning-panel {
-        grid-template-columns: 1fr;
-    }
-
-    .tutor-chat {
-        order: -1;
-    }
-}
-
-@media (max-width: 768px) {
-    .learning-panel {
-        position: relative;
-    }
-
-    .chat-open-button {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-    }
-
-    .chat-open-button::before {
-        content: '\1F4AC';
-        font-size: 1rem;
-    }
-
-    .tutor-chat {
-        order: initial;
-        position: fixed;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: auto;
-        width: min(92vw, 360px);
-        max-width: 100%;
-        height: 100dvh;
-        max-height: none;
-        padding: calc(20px + env(safe-area-inset-top)) 20px calc(28px + env(safe-area-inset-bottom));
-        border-radius: 0;
-        border-left: 1px solid #fcd9a3;
-        border-right: none;
-        border-top: none;
-        border-bottom: none;
-        box-shadow: -18px 0 36px rgba(15, 23, 42, 0.25);
-        transform: translateX(100%);
-        transition: transform 0.3s ease;
-        z-index: 1100;
-        overflow-y: auto;
-        -webkit-overflow-scrolling: touch;
-        background: #fffaf0;
-    }
-
-    .tutor-chat.is-open {
-        transform: translateX(0);
-    }
-
-    .chat-close-button {
-        display: inline-flex;
-        align-items: center;
-        gap: 4px;
-    }
-
-    .chat-close-button::before {
-        content: '\2715';
-        font-size: 0.85rem;
-    }
-
-    .chat-overlay {
-        display: none;
-        position: fixed;
-        inset: 0;
-        background: rgba(15, 23, 42, 0.45);
-        z-index: 1090;
-    }
-
-    .chat-overlay.is-active {
-        display: block;
-    }
-
-    .tutor-chat .chat-history {
-        max-height: none;
-        min-height: 0;
-    }
-
-    .tutor-chat .chat-form button {
-        align-self: stretch;
-    }
-
-    body.chat-sidebar-open {
-        overflow: hidden;
-    }
-}
-
 @media (max-width: 600px) {
     .app-header {
         padding: 20px 12px;
@@ -456,4 +529,13 @@ a {
     .panel {
         padding: 20px;
     }
-}
+
+    .learning-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .chat-toggle-button {
+        width: 100%;
+        justify-content: center;
+    }

--- a/public/index.php
+++ b/public/index.php
@@ -35,12 +35,17 @@ if ($selectedSubject !== null && $unitId !== null && $unitId !== '') {
     }
 }
 
-$pageTitle = 'Personal Tutor 学習ルーム';
+$pageTitle = 'Personal Tutor 教科と単元の選択';
 if ($selectedSubject !== null) {
     $pageTitle = $selectedSubject['name'] . ' - ' . $pageTitle;
 }
 if ($selectedUnit !== null) {
     $pageTitle = $selectedUnit['name'] . ' - ' . $pageTitle;
+}
+
+$startUrl = null;
+if ($selectedSubject !== null && $selectedUnit !== null) {
+    $startUrl = 'learn.php?subject=' . rawurlencode($selectedSubject['id']) . '&unit=' . rawurlencode($selectedUnit['id']);
 }
 ?>
 <!DOCTYPE html>
@@ -97,81 +102,27 @@ if ($selectedUnit !== null) {
         </section>
     <?php endif; ?>
 
-    <?php if ($selectedSubject !== null && $selectedUnit !== null): ?>
-        <section class="panel learning-panel">
-            <div class="learning-content">
-                <h2>3. 学習コンテンツ (<?= h($selectedUnit['name']) ?>)</h2>
-                <button type="button" class="chat-open-button" id="chat-open-button" aria-controls="chat-section" aria-expanded="false">
-                    家庭教師チャットを開く
-                </button>
-                <?php if (!empty($selectedUnit['goals']) && is_array($selectedUnit['goals'])): ?>
-                    <div class="goals">
-                        <h3>学習のめあて</h3>
-                        <ul>
-                            <?php foreach ($selectedUnit['goals'] as $goal): ?>
-                                <li><?= h($goal) ?></li>
-                            <?php endforeach; ?>
-                        </ul>
-                    </div>
-                <?php endif; ?>
-
-                <div class="explanation">
-                    <h3>解説</h3>
-                    <div class="explanation-body">
-                        <?= $selectedUnit['explanation'] ?? '<p>解説が登録されていません。</p>' ?>
-                    </div>
-                </div>
-
-                <?php if (!empty($selectedUnit['exercises']) && is_array($selectedUnit['exercises'])): ?>
-                    <div class="exercises">
-                        <h3>問題に挑戦</h3>
-                        <ol>
-                            <?php foreach ($selectedUnit['exercises'] as $exercise): ?>
-                                <li>
-                                    <h4><?= h($exercise['title'] ?? '問題') ?></h4>
-                                    <p><?= nl2br(h($exercise['question'] ?? '')) ?></p>
-                                    <?php if (!empty($exercise['hint'])): ?>
-                                        <details>
-                                            <summary>ヒントを見る</summary>
-                                            <p><?= nl2br(h($exercise['hint'])) ?></p>
-                                        </details>
-                                    <?php endif; ?>
-                                    <?php if (!empty($exercise['answer'])): ?>
-                                        <details>
-                                            <summary>答えを見る</summary>
-                                            <p><?= nl2br(h($exercise['answer'])) ?></p>
-                                        </details>
-                                    <?php endif; ?>
-                                </li>
-                            <?php endforeach; ?>
-                        </ol>
-                    </div>
-                <?php endif; ?>
-            </div>
-
-            <aside class="tutor-chat" id="chat-section" data-subject="<?= h($selectedSubject['id']) ?>" data-unit="<?= h($selectedUnit['id']) ?>" tabindex="-1" aria-labelledby="tutor-chat-title">
-                <div class="chat-header">
-                    <h2 id="tutor-chat-title">4. 家庭教師に質問しよう</h2>
-                    <button type="button" class="chat-close-button" id="chat-close-button">閉じる</button>
-                </div>
-                <p class="chat-description">分からないことがあれば、メッセージを送ってみましょう。学習中の内容を踏まえてヒントや解説が返ってきます。</p>
-                <div id="chat-history" class="chat-history" aria-live="polite"></div>
-                <form id="tutor-form" class="chat-form">
-                    <label for="question">質問を入力</label>
-                    <textarea id="question" name="question" rows="3" placeholder="例: 通分の方法をもう一度教えてください"></textarea>
-                    <button type="submit">送信</button>
-                </form>
-                <p class="chat-note">※ OpenAI API を利用して回答します。API キーが設定されていない場合はデモ応答になります。</p>
-            </aside>
-            <div class="chat-overlay" id="chat-overlay" hidden></div>
+    <?php if ($selectedSubject !== null && $selectedUnit !== null && $startUrl !== null): ?>
+        <section class="panel start-panel">
+            <h2>3. 学習を始めよう</h2>
+            <p class="start-panel__summary">
+                選択中: <strong><?= h($selectedSubject['name']) ?></strong> / <strong><?= h($selectedUnit['name']) ?></strong>
+            </p>
+            <?php if (!empty($selectedUnit['grade'])): ?>
+                <p class="start-panel__meta">対象: <?= h($selectedUnit['grade']) ?></p>
+            <?php endif; ?>
+            <?php if (!empty($selectedUnit['overview'])): ?>
+                <p class="start-panel__overview"><?= h($selectedUnit['overview']) ?></p>
+            <?php endif; ?>
+            <a class="primary-button" href="<?= h($startUrl) ?>">学習ルームを開く</a>
         </section>
     <?php elseif ($selectedSubject !== null): ?>
-        <section class="panel">
+        <section class="panel info-panel">
             <p>学習を始める単元を選んでください。</p>
         </section>
     <?php else: ?>
-        <section class="panel">
-            <p>興味のある教科を選ぶと、単元と学習コンテンツが表示されます。</p>
+        <section class="panel info-panel">
+            <p>興味のある教科を選ぶと、単元と学習コンテンツの一覧が表示されます。</p>
         </section>
     <?php endif; ?>
 </main>

--- a/public/learn.php
+++ b/public/learn.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use PersonalTutor\ContentRepository;
+
+require_once __DIR__ . '/../src/ContentRepository.php';
+
+function h(?string $value): string
+{
+    return htmlspecialchars((string) $value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+}
+
+$repository = new ContentRepository(__DIR__ . '/../data/contents.json');
+
+$subjectId = isset($_GET['subject']) ? (string) $_GET['subject'] : null;
+$unitId = isset($_GET['unit']) ? (string) $_GET['unit'] : null;
+
+$selectedSubject = null;
+$selectedUnit = null;
+$message = null;
+
+if ($subjectId === null || $subjectId === '' || $unitId === null || $unitId === '') {
+    $message = '学習を始めるには、教科と単元を選び直してください。';
+} else {
+    $selectedSubject = $repository->findSubject($subjectId);
+    if ($selectedSubject === null) {
+        $message = '指定された教科が見つかりませんでした。';
+    } else {
+        $selectedUnit = $repository->findUnit($selectedSubject['id'], $unitId);
+        if ($selectedUnit === null) {
+            $message = '指定された単元が見つかりませんでした。';
+        }
+    }
+}
+
+$pageTitle = 'Personal Tutor 学習ルーム';
+if ($selectedSubject !== null) {
+    $pageTitle = $selectedSubject['name'] . ' - ' . $pageTitle;
+}
+if ($selectedUnit !== null) {
+    $pageTitle = $selectedUnit['name'] . ' - ' . $pageTitle;
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= h($pageTitle) ?></title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+<header class="app-header">
+    <div class="header-inner">
+        <h1><a href="./">Personal Tutor</a></h1>
+        <p class="tagline">小・中学生向けの家庭教師型学習アプリ</p>
+    </div>
+</header>
+<main class="app-main app-main--learning">
+    <?php if ($message !== null): ?>
+        <section class="panel">
+            <h2>学習ルームを開けませんでした</h2>
+            <p><?= h($message) ?></p>
+            <p><a class="link-button" href="./">教科と単元の選択に戻る</a></p>
+        </section>
+    <?php else: ?>
+        <section class="panel learning-panel">
+            <div class="learning-content">
+                <div class="learning-header">
+                    <div class="learning-heading">
+                        <p class="learning-return"><a class="link-button" href="./">教科と単元の選択に戻る</a></p>
+                        <h2><?= h($selectedUnit['name']) ?></h2>
+                        <p class="learning-meta">
+                            教科: <?= h($selectedSubject['name']) ?> /
+                            対象: <?= h($selectedUnit['grade'] ?? '---') ?>
+                        </p>
+                    </div>
+                    <button type="button" class="chat-toggle-button" id="chat-toggle-button" aria-controls="chat-section" aria-expanded="false">
+                        <span class="chat-toggle-icon" aria-hidden="true">&#9776;</span>
+                        <span class="chat-toggle-label">家庭教師チャット</span>
+                    </button>
+                </div>
+
+                <?php if (!empty($selectedUnit['goals']) && is_array($selectedUnit['goals'])): ?>
+                    <div class="goals">
+                        <h3>学習のめあて</h3>
+                        <ul>
+                            <?php foreach ($selectedUnit['goals'] as $goal): ?>
+                                <li><?= h($goal) ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
+
+                <div class="explanation">
+                    <h3>解説</h3>
+                    <div class="explanation-body">
+                        <?= $selectedUnit['explanation'] ?? '<p>解説が登録されていません。</p>' ?>
+                    </div>
+                </div>
+
+                <?php if (!empty($selectedUnit['exercises']) && is_array($selectedUnit['exercises'])): ?>
+                    <div class="exercises">
+                        <h3>問題に挑戦</h3>
+                        <ol>
+                            <?php foreach ($selectedUnit['exercises'] as $exercise): ?>
+                                <li>
+                                    <h4><?= h($exercise['title'] ?? '問題') ?></h4>
+                                    <p><?= nl2br(h($exercise['question'] ?? '')) ?></p>
+                                    <?php if (!empty($exercise['hint'])): ?>
+                                        <details>
+                                            <summary>ヒントを見る</summary>
+                                            <p><?= nl2br(h($exercise['hint'])) ?></p>
+                                        </details>
+                                    <?php endif; ?>
+                                    <?php if (!empty($exercise['answer'])): ?>
+                                        <details>
+                                            <summary>答えを見る</summary>
+                                            <p><?= nl2br(h($exercise['answer'])) ?></p>
+                                        </details>
+                                    <?php endif; ?>
+                                </li>
+                            <?php endforeach; ?>
+                        </ol>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </section>
+    <?php endif; ?>
+</main>
+<?php if ($message === null && $selectedSubject !== null && $selectedUnit !== null): ?>
+    <aside class="tutor-chat" id="chat-section" data-subject="<?= h($selectedSubject['id']) ?>" data-unit="<?= h($selectedUnit['id']) ?>" tabindex="-1" aria-labelledby="tutor-chat-title" aria-hidden="true" inert>
+        <div class="chat-header">
+            <h2 id="tutor-chat-title">家庭教師に質問しよう</h2>
+            <button type="button" class="chat-close-button" id="chat-close-button">閉じる</button>
+        </div>
+        <p class="chat-description">分からないことがあれば、メッセージを送ってみましょう。学習中の内容を踏まえてヒントや解説が返ってきます。</p>
+        <div id="chat-history" class="chat-history" aria-live="polite"></div>
+        <form id="tutor-form" class="chat-form">
+            <label for="question">質問を入力</label>
+            <textarea id="question" name="question" rows="3" placeholder="例: 通分の方法をもう一度教えてください"></textarea>
+            <button type="submit">送信</button>
+        </form>
+        <p class="chat-note">※ OpenAI API を利用して回答します。API キーが設定されていない場合はデモ応答になります。</p>
+    </aside>
+    <div class="chat-overlay" id="chat-overlay" hidden></div>
+<?php endif; ?>
+<footer class="app-footer">
+    <p>&copy; <?= date('Y') ?> Personal Tutor</p>
+</footer>
+<script src="assets/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a dedicated `learn.php` page that renders the unit content with a hamburger-controlled chat drawer
- simplify `index.php` to focus on picking a subject/unit and link to the learning room
- refresh styles and JavaScript so the tutor chat opens from a hamburger button on any screen size

## Testing
- php -l public/index.php
- php -l public/learn.php

------
https://chatgpt.com/codex/tasks/task_e_68cfd3066bf483278859f70c5a0bec19