### PR TITLE
Add detailed logging for OpenAI communication failures

### DIFF
--- a/public/chat.php
+++ b/public/chat.php
@@ -69,6 +69,10 @@ try {
         'source' => 'openai'
     ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 } catch (Throwable $e) {
+    logOpenAiFailure('Failed to obtain response from OpenAI.', [
+        'exception' => get_class($e),
+        'message' => $e->getMessage(),
+    ]);
     http_response_code(500);
     echo json_encode([
         'error' => '家庭教師からの返信に失敗しました。',
@@ -128,11 +132,15 @@ function requestOpenAi(string $apiKey, array $messages): string
     ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
     if ($payload === false) {
+        logOpenAiFailure('Failed to encode request payload for OpenAI API.', [
+            'messages_count' => count($messages),
+        ]);
         throw new RuntimeException('リクエストの作成に失敗しました。');
     }
 
     $ch = curl_init('https://api.openai.com/v1/chat/completions');
     if ($ch === false) {
+        logOpenAiFailure('Failed to initialize cURL for OpenAI API request.');
         throw new RuntimeException('リクエストの初期化に失敗しました。');
     }
 
@@ -151,6 +159,11 @@ function requestOpenAi(string $apiKey, array $messages): string
 
     if ($rawResponse === false) {
         $error = curl_error($ch) ?: 'Unknown error';
+        $errno = curl_errno($ch);
+        logOpenAiFailure('cURL execution for OpenAI API failed.', [
+            'curl_error' => $error,
+            'curl_errno' => $errno,
+        ]);
         curl_close($ch);
         throw new RuntimeException('OpenAI API の呼び出しに失敗しました: ' . $error);
     }
@@ -160,20 +173,49 @@ function requestOpenAi(string $apiKey, array $messages): string
 
     $decoded = json_decode($rawResponse, true);
     if (!is_array($decoded)) {
+        logOpenAiFailure('Failed to decode OpenAI API response.', [
+            'status_code' => $statusCode,
+            'raw_response' => $rawResponse,
+        ]);
         throw new RuntimeException('OpenAI API のレスポンスが解析できませんでした。');
     }
 
     if ($statusCode >= 400) {
         $errorMessage = $decoded['error']['message'] ?? 'Unexpected error';
+        logOpenAiFailure('OpenAI API returned an error response.', [
+            'status_code' => $statusCode,
+            'error' => $decoded['error'] ?? null,
+            'raw_response' => $rawResponse,
+        ]);
         throw new RuntimeException('OpenAI API エラー: ' . $errorMessage);
     }
 
     $answer = $decoded['choices'][0]['message']['content'] ?? '';
     if ($answer === '') {
+        logOpenAiFailure('OpenAI API response did not contain an answer.', [
+            'status_code' => $statusCode,
+            'decoded_response' => $decoded,
+        ]);
         throw new RuntimeException('OpenAI API から有効な回答が得られませんでした。');
     }
 
     return $answer;
+}
+
+function logOpenAiFailure(string $message, array $context = []): void
+{
+    $logMessage = '[OpenAI][error] ' . $message;
+
+    if ($context !== []) {
+        $encodedContext = json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($encodedContext !== false) {
+            $logMessage .= ' | context: ' . $encodedContext;
+        } else {
+            $logMessage .= ' | context: ' . print_r($context, true);
+        }
+    }
+
+    error_log($logMessage);
 }
 
 function buildFallbackResponse(array $subject, array $unit, string $question, string $contextText): array


### PR DESCRIPTION
## Summary
- add a helper to log OpenAI communication failures with contextual details
- record cURL errors, response bodies, and decoded payloads before raising exceptions
- log top-level OpenAI failures so server logs capture the reason for chat errors

## Testing
- php -l public/chat.php

------
https://chatgpt.com/codex/tasks/task_e_68cfd59cbd84832781e582382298312d