### PR TITLE
Ensure tutor chat toggle remains visible while scrolling

### DIFF
--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -69,6 +69,7 @@ a {
 
 .app-main--learning {
     gap: 32px;
+    padding-bottom: 140px;
 }
 
 .panel {
@@ -243,6 +244,11 @@ a {
 }
 
 .chat-toggle-button {
+    position: fixed;
+    right: 24px;
+    right: calc(24px + env(safe-area-inset-right));
+    bottom: 24px;
+    bottom: calc(24px + env(safe-area-inset-bottom));
     display: inline-flex;
     align-items: center;
     gap: 8px;
@@ -251,12 +257,13 @@ a {
     background: #ffffff;
     color: #243b6b;
     border-radius: 999px;
-    padding: 10px 18px;
+    padding: 12px 20px;
     font-size: 0.95rem;
     font-weight: 600;
     cursor: pointer;
     box-shadow: 0 10px 24px rgba(63, 106, 216, 0.25);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, opacity 0.2s ease;
+    z-index: 1200;
 }
 
 .chat-toggle-button:hover {
@@ -275,6 +282,12 @@ a {
     color: #fff;
     border-color: transparent;
     box-shadow: 0 12px 30px rgba(63, 106, 216, 0.35);
+}
+
+body.chat-sidebar-open .chat-toggle-button {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(12px);
 }
 
 .chat-toggle-icon {
@@ -536,6 +549,10 @@ body.chat-sidebar-open {
     }
 
     .chat-toggle-button {
-        width: 100%;
-        justify-content: center;
+        right: 16px;
+        right: calc(16px + env(safe-area-inset-right));
+        bottom: 16px;
+        bottom: calc(16px + env(safe-area-inset-bottom));
+        padding: 12px 18px;
+        font-size: 0.9rem;
     }


### PR DESCRIPTION
## Summary
- anchor the tutor chat toggle button to the viewport so it stays visible regardless of scroll position
- hide the toggle while the chat drawer is open and add extra page padding to avoid overlap with content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfd628db088327831c5897b12e28be