### PR TITLE
Show OpenAI error details in chat

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -62,8 +62,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
       if (!response.ok || data.error) {
         const message = data.error || 'エラーが発生しました。時間をおいて再度お試しください。';
+        const detail = typeof data.details === 'string' ? data.details.trim() : '';
+        const composedMessage = detail ? `${message}\n${detail}` : message;
         pendingBubble.className = 'chat-bubble system';
-        pendingBubble.textContent = message;
+        pendingBubble.textContent = composedMessage;
         return;
       }
 


### PR DESCRIPTION
## Summary
- append OpenAI error diagnostics from the API response to the chat bubble when a reply fails so the user can see the details

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfd968871c8327b5f3873d5a970388