### PR TITLE
Use max_completion_tokens for GPT-5 nano requests

### DIFF
--- a/public/chat.php
+++ b/public/chat.php
@@ -129,7 +129,7 @@ function requestOpenAi(string $apiKey, array $messages): string
         'model' => 'gpt-5-nano',
         'messages' => $messages,
         'temperature' => 0.7,
-        'max_tokens' => 512,
+        'max_completion_tokens' => 512,
     ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
     if ($payload === false) {


### PR DESCRIPTION
## Summary
- update the OpenAI chat request payload to use `max_completion_tokens`

## Testing
- php -l public/chat.php

------
https://chatgpt.com/codex/tasks/task_e_68cfdb7a5d1883279190fe23f5e580d7