### PR TITLE
Fix OpenAI request payload for gpt-5-nano

### DIFF
--- a/public/chat.php
+++ b/public/chat.php
@@ -125,12 +125,13 @@ function buildChatMessages(string $contextText, $history, string $question): arr
 
 function requestOpenAi(string $apiKey, array $messages): string
 {
-    $payload = json_encode([
+    $payloadData = [
         'model' => 'gpt-5-nano',
         'messages' => $messages,
-        'temperature' => 0.7,
         'max_completion_tokens' => 512,
-    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    ];
+
+    $payload = json_encode($payloadData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
     if ($payload === false) {
         $debugInfo = formatOpenAiDebugInfo('Failed to encode request payload for OpenAI API.', [


### PR DESCRIPTION
## Summary
- stop sending an explicit temperature when calling the OpenAI API with gpt-5-nano to avoid unsupported value errors

## Testing
- php -l public/chat.php

------
https://chatgpt.com/codex/tasks/task_e_68cfdcb229608327a7950f0561415410