### PR TITLE
Make desktop chat persistent and improve error handling

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const toggleButton = document.getElementById('chat-toggle-button');
   const closeButton = document.getElementById('chat-close-button');
   const overlay = document.getElementById('chat-overlay');
+  const statusElement = document.getElementById('chat-status');
 
   if (!subjectId || !unitId || !form || !textarea || !historyContainer || !submitButton) {
     return;
@@ -44,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
       history: conversation.slice(),
     };
 
+    setStatusMessage('');
     setFormDisabled(true);
     const pendingBubble = appendBubble('system', '家庭教師が考えています…');
 
@@ -56,27 +58,45 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify(payload),
       });
 
-      const data = await response.json();
+      let data;
+      try {
+        data = await response.json();
+      } catch (parseError) {
+        removeBubble(pendingBubble);
+        setStatusMessage('回答の解析に失敗しました。時間をおいて再度お試しください。', 'error');
+        console.error('Failed to parse chat response', parseError);
+        return;
+      }
 
       if (!response.ok || data.error) {
-        const message = data.error || 'エラーが発生しました。時間をおいて再度お試しください。';
-        const detail = typeof data.details === 'string' ? data.details.trim() : '';
-        const composedMessage = detail ? `${message}\n${detail}` : message;
-        pendingBubble.className = 'chat-bubble system';
-        pendingBubble.textContent = composedMessage;
+        removeBubble(pendingBubble);
+        const message = typeof data.error === 'string' && data.error.trim() !== ''
+          ? data.error.trim()
+          : 'エラーが発生しました。時間をおいて再度お試しください。';
+        setStatusMessage(message, 'error');
+        if (typeof data.details === 'string' && data.details.trim() !== '') {
+          console.error('[PersonalTutor][chat] OpenAI error details:', data.details);
+        }
+        return;
+      }
+
+      const answer = typeof data.answer === 'string' ? data.answer : '';
+      if (answer.trim() === '') {
+        removeBubble(pendingBubble);
+        setStatusMessage('回答を取得できませんでした。時間をおいて再度お試しください。', 'error');
         return;
       }
 
       pendingBubble.className = 'chat-bubble assistant';
-      pendingBubble.textContent = data.answer || '回答を取得できませんでした。';
+      pendingBubble.textContent = answer;
+      setStatusMessage('');
 
       conversation.push({ role: 'user', content: question });
-      if (data.answer) {
-        conversation.push({ role: 'assistant', content: data.answer });
-      }
+      conversation.push({ role: 'assistant', content: answer });
     } catch (error) {
-      pendingBubble.className = 'chat-bubble system';
-      pendingBubble.textContent = '通信に失敗しました。ネットワーク環境を確認してください。';
+      removeBubble(pendingBubble);
+      setStatusMessage('通信に失敗しました。ネットワーク環境を確認してください。', 'error');
+      console.error('[PersonalTutor][chat] request failed:', error);
     } finally {
       setFormDisabled(false);
       scrollToBottom(historyContainer);
@@ -95,7 +115,14 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    const layoutQuery = window.matchMedia('(min-width: 1024px)');
+    let isDesktopLayout = layoutQuery.matches;
+
     const closeSidebar = (returnFocus = true) => {
+      if (isDesktopLayout) {
+        return;
+      }
+
       chatSection.classList.remove('is-open');
       overlay.classList.remove('is-active');
       overlay.setAttribute('hidden', 'true');
@@ -110,6 +137,10 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const openSidebar = () => {
+      if (isDesktopLayout) {
+        return;
+      }
+
       chatSection.classList.add('is-open');
       overlay.classList.add('is-active');
       overlay.removeAttribute('hidden');
@@ -122,6 +153,10 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const toggleSidebar = () => {
+      if (isDesktopLayout) {
+        return;
+      }
+
       if (chatSection.classList.contains('is-open')) {
         closeSidebar(true);
       } else {
@@ -129,18 +164,64 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     };
 
+    const applyDesktopLayout = () => {
+      isDesktopLayout = true;
+      document.body.classList.add('chat-desktop');
+      chatSection.classList.add('is-open');
+      chatSection.removeAttribute('aria-hidden');
+      chatSection.removeAttribute('inert');
+      overlay.classList.remove('is-active');
+      overlay.setAttribute('hidden', 'true');
+      document.body.classList.remove('chat-sidebar-open');
+      toggleButton.setAttribute('aria-expanded', 'true');
+      toggleButton.setAttribute('hidden', 'true');
+    };
+
+    const applyMobileLayout = () => {
+      isDesktopLayout = false;
+      document.body.classList.remove('chat-desktop');
+      toggleButton.removeAttribute('hidden');
+      closeSidebar(false);
+    };
+
+    const handleLayoutChange = (event) => {
+      if (event.matches) {
+        applyDesktopLayout();
+      } else {
+        applyMobileLayout();
+      }
+    };
+
+    if (typeof layoutQuery.addEventListener === 'function') {
+      layoutQuery.addEventListener('change', handleLayoutChange);
+    } else if (typeof layoutQuery.addListener === 'function') {
+      layoutQuery.addListener(handleLayoutChange);
+    }
+
     toggleButton.addEventListener('click', toggleSidebar);
-    closeButton.addEventListener('click', () => closeSidebar(true));
-    overlay.addEventListener('click', () => closeSidebar(true));
+    closeButton.addEventListener('click', () => {
+      if (!isDesktopLayout) {
+        closeSidebar(true);
+      }
+    });
+    overlay.addEventListener('click', () => {
+      if (!isDesktopLayout) {
+        closeSidebar(true);
+      }
+    });
 
     document.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape' && chatSection.classList.contains('is-open')) {
+      if (event.key === 'Escape' && chatSection.classList.contains('is-open') && !isDesktopLayout) {
         event.preventDefault();
         closeSidebar(true);
       }
     });
 
-    closeSidebar(false);
+    if (isDesktopLayout) {
+      applyDesktopLayout();
+    } else {
+      applyMobileLayout();
+    }
   }
 
   function appendBubble(role, text) {
@@ -152,8 +233,42 @@ document.addEventListener('DOMContentLoaded', () => {
     return bubble;
   }
 
+  function removeBubble(bubble) {
+    if (bubble && bubble.parentNode) {
+      bubble.parentNode.removeChild(bubble);
+    }
+  }
+
   function scrollToBottom(element) {
     element.scrollTop = element.scrollHeight;
+  }
+
+  function setStatusMessage(message, type = 'info') {
+    if (!statusElement) {
+      return;
+    }
+
+    if (!message) {
+      statusElement.textContent = '';
+      statusElement.classList.remove('is-error');
+      statusElement.setAttribute('role', 'status');
+      statusElement.setAttribute('aria-live', 'polite');
+      statusElement.hidden = true;
+      return;
+    }
+
+    if (type === 'error') {
+      statusElement.classList.add('is-error');
+      statusElement.setAttribute('role', 'alert');
+      statusElement.setAttribute('aria-live', 'assertive');
+    } else {
+      statusElement.classList.remove('is-error');
+      statusElement.setAttribute('role', 'status');
+      statusElement.setAttribute('aria-live', 'polite');
+    }
+
+    statusElement.textContent = message;
+    statusElement.hidden = false;
   }
 
   function setFormDisabled(disabled) {

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -205,6 +205,12 @@ a {
     padding: 24px;
 }
 
+.learning-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
 .learning-content {
     display: flex;
     flex-direction: column;
@@ -389,6 +395,47 @@ body.chat-sidebar-open .chat-toggle-button {
     }
 }
 
+body.chat-desktop .app-main--learning {
+    max-width: 1360px;
+}
+
+body.chat-desktop .learning-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 380px);
+    gap: 32px;
+    align-items: flex-start;
+}
+
+body.chat-desktop .learning-panel {
+    margin: 0;
+}
+
+body.chat-desktop .tutor-chat {
+    position: sticky;
+    top: 24px;
+    right: auto;
+    bottom: auto;
+    width: 100%;
+    max-width: none;
+    height: auto;
+    max-height: calc(100vh - 64px);
+    padding: 24px;
+    border-radius: 16px;
+    border: 1px solid #fcd9a3;
+    box-shadow: var(--shadow);
+    transform: none;
+}
+
+body.chat-desktop .tutor-chat.is-open {
+    transform: none;
+}
+
+body.chat-desktop .chat-toggle-button,
+body.chat-desktop .chat-close-button,
+body.chat-desktop .chat-overlay {
+    display: none !important;
+}
+
 .chat-overlay {
     display: none;
     position: fixed;
@@ -448,6 +495,20 @@ body.chat-sidebar-open {
     margin: 0;
     font-size: 0.9rem;
     color: #8b5c11;
+}
+
+.chat-status {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #8b5c11;
+}
+
+.chat-status.is-error {
+    color: #b45309;
+    background: rgba(245, 158, 11, 0.12);
+    border: 1px solid rgba(245, 158, 11, 0.35);
+    border-radius: 8px;
+    padding: 8px 12px;
 }
 
 .chat-history {

--- a/public/learn.php
+++ b/public/learn.php
@@ -65,9 +65,10 @@ if ($selectedUnit !== null) {
             <p><a class="link-button" href="./">教科と単元の選択に戻る</a></p>
         </section>
     <?php else: ?>
-        <section class="panel learning-panel">
-            <div class="learning-content">
-                <div class="learning-header">
+        <div class="learning-layout">
+            <section class="panel learning-panel">
+                <div class="learning-content">
+                    <div class="learning-header">
                     <div class="learning-heading">
                         <p class="learning-return"><a class="link-button" href="./">教科と単元の選択に戻る</a></p>
                         <h2><?= h($selectedUnit['name']) ?></h2>
@@ -127,22 +128,26 @@ if ($selectedUnit !== null) {
                 <?php endif; ?>
             </div>
         </section>
+        <?php if ($selectedSubject !== null && $selectedUnit !== null): ?>
+            <aside class="tutor-chat" id="chat-section" data-subject="<?= h($selectedSubject['id']) ?>" data-unit="<?= h($selectedUnit['id']) ?>" tabindex="-1" aria-labelledby="tutor-chat-title" aria-hidden="true" inert>
+                <div class="chat-header">
+                    <h2 id="tutor-chat-title">家庭教師に質問しよう</h2>
+                    <button type="button" class="chat-close-button" id="chat-close-button">閉じる</button>
+                </div>
+                <p class="chat-description">分からないことがあれば、メッセージを送ってみましょう。学習中の内容を踏まえてヒントや解説が返ってきます。</p>
+                <p id="chat-status" class="chat-status" role="status" aria-live="polite" hidden></p>
+                <div id="chat-history" class="chat-history" aria-live="polite"></div>
+                <form id="tutor-form" class="chat-form">
+                    <label for="question">質問を入力</label>
+                    <textarea id="question" name="question" rows="3" placeholder="例: 通分の方法をもう一度教えてください"></textarea>
+                    <button type="submit">送信</button>
+                </form>
+            </aside>
+        <?php endif; ?>
+        </div>
     <?php endif; ?>
 </main>
 <?php if ($message === null && $selectedSubject !== null && $selectedUnit !== null): ?>
-    <aside class="tutor-chat" id="chat-section" data-subject="<?= h($selectedSubject['id']) ?>" data-unit="<?= h($selectedUnit['id']) ?>" tabindex="-1" aria-labelledby="tutor-chat-title" aria-hidden="true" inert>
-        <div class="chat-header">
-            <h2 id="tutor-chat-title">家庭教師に質問しよう</h2>
-            <button type="button" class="chat-close-button" id="chat-close-button">閉じる</button>
-        </div>
-        <p class="chat-description">分からないことがあれば、メッセージを送ってみましょう。学習中の内容を踏まえてヒントや解説が返ってきます。</p>
-        <div id="chat-history" class="chat-history" aria-live="polite"></div>
-        <form id="tutor-form" class="chat-form">
-            <label for="question">質問を入力</label>
-            <textarea id="question" name="question" rows="3" placeholder="例: 通分の方法をもう一度教えてください"></textarea>
-            <button type="submit">送信</button>
-        </form>
-    </aside>
     <div class="chat-overlay" id="chat-overlay" hidden></div>
 <?php endif; ?>
 <footer class="app-footer">


### PR DESCRIPTION
## Summary
- ensure the tutor chat appears alongside the learning content on desktop and add supporting layout styles
- add a status area and update the chat script so OpenAI/network errors are reported outside of the chat history
- parse OpenAI responses more flexibly to avoid missing-answer failures

## Testing
- php -l public/learn.php
- php -l public/chat.php

------
https://chatgpt.com/codex/tasks/task_e_68cfe18b7c1c83278a64c5d45a6afe0b