### PR TITLE
Fix OpenAI input content type

### DIFF
--- a/public/chat.php
+++ b/public/chat.php
@@ -161,11 +161,16 @@ function convertMessagesToResponseInput(array $messages): array
             continue;
         }
 
+        $contentType = match ($role) {
+            'assistant' => 'output_text',
+            default => 'input_text',
+        };
+
         $input[] = [
             'role' => $role,
             'content' => [
                 [
-                    'type' => 'text',
+                    'type' => $contentType,
                     'text' => $contentText,
                 ],
             ],


### PR DESCRIPTION
## Summary
- adjust request payload construction for the Responses API to use the supported content type values
- differentiate between user/system history and assistant outputs so the API accepts the chat transcript

## Testing
- php -l public/chat.php

------
https://chatgpt.com/codex/tasks/task_e_68cfe912ae5c8327981bcb9a95d6cb68